### PR TITLE
Refine support interfaces with professional white theme

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2,13 +2,13 @@
 <html lang="fr">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>Admin / Formateur — Simulateur SAV</title>
+<title>Administration Support Client</title>
 <link rel="stylesheet" href="/style.css" />
 <body>
-<header class="bar"><h1>Dashboard formateur</h1><div><button class="btn" id="reload">Recharger</button></div></header>
+<header class="bar"><h1>Tableau de bord administration</h1><div><button class="btn" id="reload">Actualiser</button></div></header>
 <main style="padding:16px">
   <div class="card">
-    <div class="small">Accès réservé aux <b>formateurs</b>. Si vous voyez une erreur 403, demandez à l'admin de vous donner le rôle trainer.</div>
+    <div class="small">Accès strictement réservé aux responsables du support. Vous pouvez consulter l'ensemble des conversations et suivre les indicateurs de performance.</div>
   </div>
   <div id="kpis" class="grid"></div>
   <div class="card">

--- a/chat.html
+++ b/chat.html
@@ -2,27 +2,28 @@
 <html lang="fr">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>Simulateur SAV — Chat</title>
+<title>Espace agent — Conversation client</title>
 <link rel="stylesheet" href="/style.css" />
 <body>
 <header class="bar">
-  <h1>Chat de simulation</h1>
-  <div class="small"><a href="/scenarios.html" style="color:#60a5fa;text-decoration:none">← Scénarios</a></div>
+  <h1>Conversation client</h1>
+  <div class="small"><a href="/scenarios.html" style="color:#1d4ed8;text-decoration:none">← Dossiers clients</a></div>
 </header>
 
 <main class="layout">
   <section id="thread" class="thread"></section>
   <aside class="actions">
-    <h3>Actions SAV</h3>
+    <h3>Actions de suivi</h3>
     <button class="btn" data-act="rma">Créer RMA</button>
-    <button class="btn" data-act="discount">-20% (test)</button>
-    <button class="btn" data-act="score" style="background:#22c55e;color:#05240e">Clôturer & scorer</button>
-    <div class="alert small">Session: <span id="sid"></span></div>
+    <button class="btn" data-act="discount">Appliquer un geste commercial</button>
+    <button class="btn" data-act="score" style="background:#16a34a">Clôturer & scorer</button>
+    <div class="alert small">Identifiant dossier: <span id="sid"></span></div>
+    <div class="alert small" style="margin-top:8px">Rappel: le correspondant reste un client réel pour vous. Ne mentionnez jamais d'outils internes ni d'IA.</div>
   </aside>
 </main>
 
 <footer class="composer">
-  <input id="msg" placeholder="Tape ton message..." />
+  <input id="msg" placeholder="Rédigez votre réponse client..." />
   <button class="btn" id="send">Envoyer</button>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -2,41 +2,60 @@
 <html lang="fr">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>Connexion agent</title>
+<title>Espace Support Client</title>
 <link rel="stylesheet" href="/style.css" />
 <body>
-<header class="bar"><h1>Simulateur SAV — Connexion agent</h1></header>
-<main style="padding:16px;max-width:640px;margin:0 auto">
-  <div class="card">
-    <h2>Se connecter</h2>
-    <p class="small">Utilisez votre email et mot de passe d'agent.</p>
-    <div style="display:grid;gap:8px">
-      <input id="email" placeholder="email@exemple.fr" />
-      <input id="pass" type="password" placeholder="Mot de passe" />
-      <button class="btn" id="login">Connexion</button>
+<header class="bar"><h1>Plateforme Support Client</h1></header>
+<main style="padding:32px 16px;max-width:720px;margin:0 auto">
+  <div class="card" style="margin-top:0">
+    <h2 style="margin-top:0">Bienvenue</h2>
+    <p class="small">Accédez à votre espace dédié pour traiter les demandes clients ou superviser les conversations en cours.</p>
+    <div style="display:grid;gap:14px;margin-top:18px">
+      <label class="small" for="email">Adresse e-mail professionnelle</label>
+      <input id="email" placeholder="prenom.nom@entreprise.fr" autocomplete="username" />
+      <label class="small" for="pass">Mot de passe</label>
+      <input id="pass" type="password" placeholder="••••••••" autocomplete="current-password" />
+      <div style="display:flex;gap:12px;flex-wrap:wrap">
+        <button class="btn" data-target="agent">Connexion agent</button>
+        <button class="btn" data-target="admin" style="background:#0f172a">Connexion administration</button>
+      </div>
     </div>
-    <div id="msg" class="small" style="margin-top:8px"></div>
+    <div id="msg" class="small" style="margin-top:12px"></div>
   </div>
-  <div class="alert small">
-    Astuce: après connexion, vous serez redirigé vers le <b>sélecteur de scénarios</b>.
+  <div class="grid" style="margin-top:24px">
+    <div class="card">
+      <h3 style="margin:0 0 8px 0">Espace agent</h3>
+      <p class="small">Préparez vos réponses, appliquez les gestes commerciaux autorisés et restez strictement dans le rôle d'un conseiller clientèle.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin:0 0 8px 0">Tableau de bord administration</h3>
+      <p class="small">Suivez l'ensemble des conversations, évaluez les performances et assurez la conformité de chaque échange.</p>
+    </div>
   </div>
 </main>
 <script src="https://unpkg.com/@supabase/supabase-js@2.47.6/dist/umd/supabase.js"></script>
 <script>
 const client = supabase.createClient("https://bkgpmfqzkzxehjgshnga.supabase.co", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJrZ3BtZnF6a3p4ZWhqZ3NobmdhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk5MDM2NDAsImV4cCI6MjA3NTQ3OTY0MH0.1BHkv-grxjDz92bovjDjb-8dHaWPSvQruudVx1kkdqw");
 const msg = document.getElementById('msg');
-document.getElementById('login').onclick = async () => {
-  msg.textContent = "Connexion...";
+async function signIn(target) {
+  msg.textContent = "Vérification des accès...";
   const email = document.getElementById('email').value.trim();
   const pass  = document.getElementById('pass').value.trim();
+  if (!email || !pass) { msg.textContent = "Merci de renseigner vos identifiants."; return; }
   const { data, error } = await client.auth.signInWithPassword({ email, password: pass });
   if (error) { msg.textContent = "Erreur: " + error.message; return; }
   const token = data.session?.access_token;
-  if (!token) { msg.textContent = "Pas de token retourné."; return; }
-  // Stocke le token en local puis redirige
+  if (!token) { msg.textContent = "Connexion refusée."; return; }
   localStorage.setItem("sav_token", token);
-  location.href = "/scenarios.html";
-};
+  if (target === "admin") {
+    location.href = "/admin.html";
+  } else {
+    location.href = "/scenarios.html";
+  }
+}
+document.querySelectorAll('[data-target]').forEach(btn => {
+  btn.addEventListener('click', () => signIn(btn.dataset.target));
+});
 </script>
 </body>
 </html>

--- a/scenarios.html
+++ b/scenarios.html
@@ -2,16 +2,16 @@
 <html lang="fr">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>Sélecteur de scénarios</title>
+<title>Espace agent — Sélection des dossiers</title>
 <link rel="stylesheet" href="/style.css" />
 <body>
-<header class="bar"><h1>Simulateur SAV — Scénarios</h1><div class="small" id="uinfo"></div></header>
+<header class="bar"><h1>Espace agent — Dossiers clients</h1><div class="small" id="uinfo"></div></header>
 <main style="padding:16px">
   <div class="card">
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-      <button class="btn" id="reload">Recharger</button>
-      <button class="btn" id="logout" style="background:#ef4444;color:#fff">Déconnexion</button>
-      <span class="small">Token stocké en local (navigateur).</span>
+      <button class="btn" id="reload">Actualiser</button>
+      <button class="btn" id="logout" style="background:#b91c1c;color:#fff">Déconnexion</button>
+      <span class="small">Utilisez uniquement votre accès professionnel. L'assistant reste strictement positionné comme client.</span>
     </div>
   </div>
   <div id="list" class="grid"></div>

--- a/style.css
+++ b/style.css
@@ -1,22 +1,35 @@
-:root { --bg:#0f172a; --panel:#111827; --card:#1f2937; --text:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; }
+:root {
+  --bg:#f4f6fb;
+  --panel:#ffffff;
+  --card:#ffffff;
+  --text:#142033;
+  --muted:#5f6b7c;
+  --accent:#1d4ed8;
+  --border:#d7dbe2;
+  --agent:#1d4ed8;
+  --client:#eef2ff;
+}
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Arial}
-header.bar{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:var(--panel);border-bottom:1px solid #222}
-.bar h1{margin:0;font-size:18px}
-.card{background:var(--card);border:1px solid #273244;border-radius:12px;padding:12px;margin:10px 0}
-.btn{background:var(--accent);color:#0b1220;border:none;border-radius:8px;padding:10px 14px;font-weight:700;cursor:pointer}
-input,textarea{background:#0b1220;color:var(--text);border:1px solid #223;border-radius:8px;padding:10px}
-.grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fill,minmax(280px,1fr))}
-.small{color:var(--muted);font-size:12px}
-.layout{display:grid;grid-template-columns:1fr 300px;gap:12px;padding:12px}
-.thread{background:var(--card);border:1px solid #273244;border-radius:12px;padding:12px;height:68vh;overflow:auto}
-.msg{display:flex;margin:8px 0;gap:8px}
-.msg .bubble{max-width:70%;padding:10px 12px;border-radius:12px;line-height:1.35;white-space:pre-wrap}
+body{margin:0;background:var(--bg);color:var(--text);font-family:"Segoe UI",system-ui,-apple-system,BlinkMacSystemFont,"Roboto",sans-serif}
+header.bar{display:flex;align-items:center;justify-content:space-between;padding:16px 24px;background:var(--panel);border-bottom:1px solid var(--border);box-shadow:0 1px 2px rgba(15,23,42,0.06)}
+.bar h1{margin:0;font-size:20px;font-weight:600;color:var(--text)}
+.card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;margin:14px 0;box-shadow:0 6px 18px rgba(20,32,51,0.04)}
+.btn{background:var(--accent);color:#fff;border:none;border-radius:10px;padding:12px 16px;font-weight:600;cursor:pointer;transition:box-shadow .2s ease,transform .2s ease}
+.btn:hover{box-shadow:0 10px 20px rgba(29,78,216,0.18);transform:translateY(-1px)}
+.btn:disabled{opacity:.6;cursor:not-allowed;box-shadow:none;transform:none}
+input,textarea{background:#fff;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:12px;font-size:15px;transition:border-color .2s ease,box-shadow .2s ease}
+input:focus,textarea:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px rgba(29,78,216,0.18)}
+.grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fill,minmax(280px,1fr))}
+.small{color:var(--muted);font-size:13px;line-height:1.4}
+.layout{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:20px;padding:20px}
+.thread{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;height:68vh;overflow:auto;box-shadow:0 6px 18px rgba(20,32,51,0.04)}
+.msg{display:flex;margin:10px 0;gap:10px}
+.msg .bubble{max-width:72%;padding:12px 14px;border-radius:14px;line-height:1.45;white-space:pre-wrap;font-size:15px}
 .msg.agent{justify-content:flex-end}
-.msg.agent .bubble{background:#0ea5e9;color:#07131a;border-top-right-radius:4px}
-.msg.bot .bubble{background:#0b1220;border:1px solid #253049;border-top-left-radius:4px}
-.actions{background:var(--card);border:1px solid #273244;border-radius:12px;padding:12px;height:68vh;overflow:auto}
-footer.composer{display:flex;gap:8px;padding:12px;border-top:1px solid #222;background:var(--panel);position:sticky;bottom:0}
+.msg.agent .bubble{background:var(--agent);color:#fff;border-top-right-radius:6px}
+.msg.bot .bubble{background:var(--client);border:1px solid rgba(29,46,108,0.18);border-top-left-radius:6px}
+.actions{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;height:68vh;overflow:auto;box-shadow:0 6px 18px rgba(20,32,51,0.04)}
+footer.composer{display:flex;gap:10px;padding:16px 24px;border-top:1px solid var(--border);background:var(--panel);position:sticky;bottom:0}
 footer.composer input{flex:1}
-.alert{padding:10px;border-radius:8px;background:#0b1220;border:1px solid #2a334a;margin:12px 0}
+.alert{padding:12px;border-radius:12px;background:#f8fafc;border:1px solid var(--border);margin:16px 0}
 .center{display:flex;align-items:center;justify-content:center;height:70vh}


### PR DESCRIPTION
## Summary
- restyle the shared CSS with a bright, professional palette and refined components
- update the login, agent, chat, and admin pages to remove simulation wording and clarify each workspace
- add split navigation on the landing page for agent and administration access with targeted redirects

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e67c711d2083339880a883c2f4c719